### PR TITLE
Update the project for Wagtail 6 (breaking changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ ORDERING_FIELD = 'my_order'
 ###### In wagtail_hooks.py, add a mixin class to augment the functionality for sorting (be sure to put the mixin class before ModelAdmin):
 
 ```python
-from wagtail.contrib.modeladmin.options import ModelAdmin
+from wagtail_modeladmin.options import ModelAdmin
 from wagtail_adminsortable.admin import SortableAdminMixin
 
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ setup(
         'Framework :: Wagtail',
     ],
     install_requires=[
-        'wagtail>=2.15.0'
+        "wagtail>=6",
+        "wagtail-modeladmin",
     ],
     packages=find_packages(exclude=['example', 'docs']),
     include_package_data=True,

--- a/wagtail_adminsortable/templatetags/adminsortable_tags.py
+++ b/wagtail_adminsortable/templatetags/adminsortable_tags.py
@@ -2,7 +2,7 @@ from django.template import Library
 from django.forms.utils import flatatt
 from django.utils.safestring import mark_safe
 from django.contrib.admin.templatetags.admin_list import result_headers
-from wagtail.contrib.modeladmin.templatetags.modeladmin_tags import results
+from wagtail_modeladmin.templatetags.modeladmin_tags import results
 
 register = Library()
 

--- a/wagtail_adminsortable/views.py
+++ b/wagtail_adminsortable/views.py
@@ -1,5 +1,5 @@
 from django.views.generic import FormView
-from wagtail.contrib.modeladmin.views import IndexView
+from wagtail_modeladmin.views import IndexView
 
 from .forms import SortableForm
 from .mixins import AjaxableResponseMixin


### PR DESCRIPTION
Update the project to work with Wagtail 6 and above.

This is a breaking change because Wagtail Model Admin was removed from Wagtail core and into a separate package