### PR TITLE
Update views.py

### DIFF
--- a/wagtail_adminsortable/views.py
+++ b/wagtail_adminsortable/views.py
@@ -1,5 +1,5 @@
 from django.views.generic import FormView
-from wagtail.contrib.modeladmin.views import IndexView
+from wagtail_modeladmin.views import IndexView
 
 from .forms import SortableForm
 from .mixins import AjaxableResponseMixin


### PR DESCRIPTION
The wagtail.contrib.modeladmin app has been removed from wagtail 6.0. If you wish to continue using it, it is available as the external package wagtail-modeladmin.